### PR TITLE
Hotfix/suggest

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "web-vitals": "^4.2.4"
   },
   "scripts": {
-    "start": "vite",
+    "start": "vite --host",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "jest --silent",

--- a/src/components/header/StationSearchBox.tsx
+++ b/src/components/header/StationSearchBox.tsx
@@ -116,7 +116,10 @@ const StationSearchBox: FC<SearchProps> = ({ onSuggestionSelected, inputFocusReq
         onSuggestionsClearRequested={onSuggestionsClearRequested}
         multiSection={true}
         getSuggestionValue={(suggestion) => suggestion.name}
-        getSectionSuggestions={(section) => section.list}
+        // workaround for bug
+        // undefined may be passed only on mobile devices with React 18
+        // https://github.com/moroshko/react-autosuggest/issues/853
+        getSectionSuggestions={(section) => section?.list ?? []}
         renderSectionTitle={renderSectionTitle}
         renderSuggestion={renderSuggestion}
         onSuggestionSelected={(_, data) => onSuggestionSelected(data.suggestion)}

--- a/src/components/map/MarkerCluster.tsx
+++ b/src/components/map/MarkerCluster.tsx
@@ -88,10 +88,8 @@ const MarkerCluster: React.FC<MarkerClusterProps> = ({ renderer, algorithm, chil
       queue.removed.slice(0)
     } else {
       clusterer.clearMarkers()
-      markers.forEach(m => {
-        m.map = null
-        queue.added.push(m)
-      })
+      markers.forEach(m => queue.added.push(m))
+      queue.added.forEach(m => m.map = null)
       markers.clear()
     }
   }, [map, clusterer, updateCount, queue, visible, markers])


### PR DESCRIPTION
# チケット


# 概要

React 18 + mobile device 限定条件で発生するバグ
https://github.com/moroshko/react-autosuggest/issues/853


# 動作確認

<!-- TODO ブラウザテストで自動化したい -->

- [ ] 単体テストは通るか？ `npm run test`
- [ ] 手動による動作確認（回帰テスト）は実施しましたか？

<details>
<summary>UIテストの観点表</summary>

- [ ] 基本的な画面表示
  - GoogleMapが表示できる
  - ヘッダーが表示される
  - 駅ピン・ボロノイ図形が地図上に描画される
  - 地図を移動・zoom変更できる
  - GoogleMapの地図タイプを変更できる
- [ ] 駅・路線ダイアログ
  - 地図タップすると一番近い駅ダイアログが表示される
    - 選択した駅ピンを表示
    - 他の駅ピンは非表示
    - ボロノイ図形は表示まま
    - レーダーリスト（駅座標から近い順）をタップすると駅ダイアログを表示
  - 地図をロングタプ・右クリックすると一番近い駅ダイアログ（座標指定）が表示される
    - 通常の駅ダイアログと同等
    - 選択地点にもピンが表示される
  - 駅ダイアログの登録路線タップで路線ダイアログを表示
    - すべての駅ピンを非表示
    - ボロノイ図形は表示まま
    - 登録駅一覧以外が即時に表示
    - 登録駅一覧を非同期で取得して表示
- [ ] 路線ポリライン
  - 路線ダイアログの地図アイコンタップでポリライン表示
  - 登録駅のピンを表示  
  - ポリライン範囲の中心に地図を移動
  - ポリライン全体が地図に表示できるzoomを調整
  - 他の駅ピンは非表示
- [ ] 高次ボロノイ図形  
  - 駅ダイアログのボロノイアイコンをタップすると、ボロノイ図形の計算を開始
  - 他の駅ピンを非表示
  - 駅のボロノイ図形を非表示
  - 地図のタップ機能は無効化
  - レーダー数の次数までボロノイ図形を順次計算して描画する
  - バツボタン押下で計算をキャンセルできる
  - バツボタン押下で駅ピン・ボロノイ図形の描画を戻す＆地図タップ機能も有効化
- [ ] URLクエリの処理  
  各状態でのクエリ＆クエリ指定でページ表示した場合の挙動
  - 現在位置表示OFF
    - idle: lat, lng, zoom → 指定位置・zoomに地図中心を移動
    - 駅ダイアログ: code（駅コード）→ 指定した駅座標に地図中心＆駅ダイアログ表示（zoomは初期値）
    - 駅ダイアログ＆ボロノイ表示: code（駅コード）, voronoi=1 → 指定した駅座標に地図中心＆駅ダイアログ表示＆ボロノイ図形の計算を開始
    - 駅ダイアログ（位置指定）：lat, lng, dialog=1 → 指定した地点に地図移動＆駅ダイアログ表示（zoomは初期値）
    - 路線ダイアログ：code（路線コード） → 路線ダイアログ表示＆路線ポリライン表示＆地図の中心はポリライン範囲の中心（zoomも調整する）
  - 現在位置表示ON
    OFFと異なる挙動はidleのみ
    - idle: mylocation=1 → 現在位置表示をONに設定＆現在位置を取得して地図移動
- [ ] 現在位置の表示  
  位置情報の権限がある状態で、
  - 現在位置ボタン押下すると現在位置に地図中心を移動する
  - 現在位置の監視
    「現在位置の表示」をONにすると...
    - 現在位置にピンが表示される
    - 駅路・路線ダイアログ非表示の間は現在位置ダイアログが表示される
    - 現在位置が変化するとピンの位置が変化し、地図の中心位置も自動追従する
    - 駅・路線ダイアログを表示すると現在位置変化しても地図は自動追従しない
    - バツボタンでダイアログ閉じても地図は自動追従しない
    - 現在位置ボタン押下で地図が自動追従再開する
- [ ] 駅ピン・クラスタリング  
  選択された駅・路線のポリライン表示時の登録駅ピンを除く
  - ピン表示OFF: ピン無し
  - ピン表示ON
    - 駅座標にピンが表示される
    - zoom >= 13 では必ず全ての駅のピンを表示
    - zoom <= 12 では駅密度に応じてピンをクラスタリングして表示する
      - 駅ピンが密集している部分がクラスター表示される
      - 疎な駅ピンはそのまま表示される
      - クラスターに含まれる駅数はラベルで表示
      - クラスターの最小駅数は3
      - 平均より多い駅を含むクラスターは濃い色で表示される
  - データセット切替時にピン・クラスターが正しく表示されること
- [ ] 駅voronoi図形の描画
  - 駅のvoronoi図形が地図上に描画される
  - 低zoomで図形面積が小さい場合は非表示
- [ ] データセット変更
  - 設定からデータセットを変更できる
  - extraの独自駅は異なる色の駅ピンが表示される
- [ ] 駅・路線の検索機能
  - ヘッダーの検索アイコンをタップすると、検索バーが表示＆入力フォームにフォーカスが当たる
  - ひらがな入力中 or 一文字は検索なし  
  - 駅・路線の名称とかな名に検索がヒットする
  - 重複防止の接尾語にはヒットしない
  - ヒットした候補をカーソルキーで選択可能
  - 候補をタップすると駅・路線のダイアログ表示（駅の場合は地図中心を移動）
- [ ] ヘルプページ
  - ヘッダーのヘルプアイコンタップで表示
  - 別ウィンドウで表示  

</details>


# スクリーンショット

| before | after  |  
|--------|--------|  
| XXX    | XXX    |  

# 備考
